### PR TITLE
Fix go get statement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This package provides a framework for writing validations for Go applications. I
 ## Installation
 
 ```bash
-$ go get https://github.com/markbates/validate
+$ go get github.com/markbates/validate
 ```
 
 ## Usage


### PR DESCRIPTION
The installation command in the README had `https://` prepended to it, which can't be used with `go get`.

```
$ go get https://github.com/markbates/validate
package https:/github.com/markbates/validate: "https://" not allowed in import path
```

I really like this approach to validation by the way! Great stuff Mark, thanks for open-sourcing it.
