### PR TITLE
[IntIsGreaterThan] Added name of validated field to error message

### DIFF
--- a/validators/int_is_greater_than.go
+++ b/validators/int_is_greater_than.go
@@ -6,14 +6,16 @@ import (
 	"github.com/markbates/validate"
 )
 
+// IntIsGreaterThan represents the name and the value of the field to compare with another value.
 type IntIsGreaterThan struct {
 	Name     string
 	Field    int
 	Compared int
 }
 
+// IsValid checks if the field's value is greater than the desired one.
 func (v *IntIsGreaterThan) IsValid(errors *validate.Errors) {
 	if !(v.Field > v.Compared) {
-		errors.Add(GenerateKey(v.Name), fmt.Sprintf("%d is not greater than %d.", v.Field, v.Compared))
+		errors.Add(GenerateKey(v.Name), fmt.Sprintf("%s: %d is not greater than %d.", v.Name, v.Field, v.Compared))
 	}
 }

--- a/validators/int_is_greater_than_test.go
+++ b/validators/int_is_greater_than_test.go
@@ -19,5 +19,5 @@ func Test_IntIsGreaterThan(t *testing.T) {
 	v = IntIsGreaterThan{Name: "number", Field: 1, Compared: 2}
 	v.IsValid(errors)
 	r.Equal(1, errors.Count())
-	r.Equal(errors.Get("number"), []string{"1 is not greater than 2."})
+	r.Equal(errors.Get("number"), []string{"number: 1 is not greater than 2."})
 }


### PR DESCRIPTION
Hi,

I created a struct with many int fields and had troubles to get what field was invalid.
So I added the name in the error message.

I just hope is something helpful for other devs too.